### PR TITLE
implemented usage of handlebars template language

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ To override this behavior you can set to false the ```useTemplateDefaults``` att
     ],
 ```
 
+Since **version 1.5.0** the component has a configurable property ```templateLanguage``` that can contain either 'mailchimp' or 'handlebars' ('mailchimp' is by default).
+
+You can change preferred language by editing ```templateLanguage``` attribute in the component configuration
+
+```
+    'mailer' => [
+        'class' => 'nickcv\mandrill\Mailer',
+        'apikey' => 'YourApiKey',
+        'useMandrillTemplates' => true,
+        'templateLanguage' => nickcv\mandrill\Mailer::LANGUAGE_HANDLEBARS,
+    ],
+```
+
 
 Additional Methods
 ------------------

--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ To override this behavior you can set to false the ```useTemplateDefaults``` att
 
 Since **version 1.5.0** the component has a configurable property ```templateLanguage``` that can contain either 'mailchimp' or 'handlebars' ('mailchimp' is by default).
 
+For more information about handlebars usage check these links:
+
+- [Mandrill docs](https://mandrill.zendesk.com/hc/en-us/articles/205582537-Using-Handlebars-for-dynamic-content)
+- [Handlebars docs](http://handlebarsjs.com/)
+
 You can change preferred language by editing ```templateLanguage``` attribute in the component configuration
 
 ```

--- a/tests/unit/MandrillMessageTest.php
+++ b/tests/unit/MandrillMessageTest.php
@@ -61,6 +61,7 @@ class MandrillMessageTest extends \Codeception\TestCase\Test
 
     public function testSetTemplateData()
     {
+        // mailchimp
         $this->assertInstanceOf('\nickcv\mandrill\Message', $this->_message->setTemplateData('viewName', [
             'money' => 300,
         ]));
@@ -73,6 +74,23 @@ class MandrillMessageTest extends \Codeception\TestCase\Test
                 'content' => 300,
             ]
         ], $this->_message->getTemplateContent());
+
+        // handlebars
+        $this->assertInstanceOf('\nickcv\mandrill\Message', $this->_message->setTemplateData('viewName', [
+            'money' => 300,
+        ], \nickcv\mandrill\Message::LANGUAGE_HANDLEBARS));
+
+        $this->assertEquals('viewName', $this->_message->getTemplateName());
+
+        $this->assertEquals([
+            [
+                'name' => 'money',
+                'content' => 300,
+            ]
+        ], $this->_message->getGlobalMergeVars());
+
+        $this->assertEquals(\nickcv\mandrill\Message::LANGUAGE_HANDLEBARS,
+            $this->_message->getMandrillMessageArray()['merge_language']);
     }
 
     public function testMessageSetRecipient()

--- a/tests/unit/MandrillTest.php
+++ b/tests/unit/MandrillTest.php
@@ -33,7 +33,14 @@ class MandrillTest extends \Codeception\TestCase\Test
         $this->setExpectedException('yii\base\InvalidConfigException', '"nickcv\mandrill\Mailer::apikey" length should be greater than 0.');
         new \nickcv\mandrill\Mailer(['apikey'=>' ']);
     }
-    
+
+    public function testTemplateLanguageIsValid()
+    {
+        $this->setExpectedException('yii\base\InvalidConfigException', '"nickcv\mandrill\Mailer::::templateLanguage" has an invalid value.');
+
+        new \nickcv\mandrill\Mailer(['templateLanguage' => 'invalid']);
+    }
+
     public function testSetUseMandrillTemplates()
     {
         $mandrillWithoutTemplates = new \nickcv\mandrill\Mailer(['apikey'=>'testing']);
@@ -62,7 +69,7 @@ class MandrillTest extends \Codeception\TestCase\Test
 
         $this->assertTrue($result);
     }
-    
+
     public function testSendMessageUsingMandrillTemplate()
     {
         $mandrill = new \nickcv\mandrill\Mailer([
@@ -79,9 +86,26 @@ class MandrillTest extends \Codeception\TestCase\Test
 
         $this->assertTrue($result);
     }
-    
+
+    public function testSendMessageUsingMandrillTemplateHandlebars()
+    {
+        $mandrill = new \nickcv\mandrill\Mailer([
+            'apikey'=>'raHz6vHU9J2YxN-F1QryTw',
+            'useMandrillTemplates' => true,
+        ]);
+        $result = $mandrill->compose('testTemplateHandlebars', ['variable' => 'test content'])
+            ->setTo('test@example.com')
+            ->setSubject('test template email')
+            ->embed($this->getTestImagePath())
+            ->attach($this->getTestPdfPath())
+            ->setGlobalMergeVars(['MERGEVAR' => 'prova'])
+            ->send();
+
+        $this->assertTrue($result);
+    }
+
     public function testCannotSendIfMandrillTemplateNotFound()
-    {   
+    {
         $mandrill = new \nickcv\mandrill\Mailer([
             'apikey'=>'raHz6vHU9J2YxN-F1QryTw',
             'useMandrillTemplates' => true,


### PR DESCRIPTION
@nickcv-ln you need to create new template called `testTemplateHandlebars` and containing smth with `{{ variable }}` to make test `testSendMessageUsingMandrillTemplateHandlebars` passing.
